### PR TITLE
[ISSUE 85] Repair preferred leader bug

### DIFF
--- a/src/main/java/io/openmessaging/storage/dledger/MemberState.java
+++ b/src/main/java/io/openmessaging/storage/dledger/MemberState.java
@@ -127,6 +127,13 @@ public class MemberState {
         return currTerm;
     }
 
+    public synchronized void revertToFollower(long term, String leaderId) {
+        PreConditions.check(role == CANDIDATE, DLedgerResponseCode.ILLEGAL_MEMBER_STATE, "%s != %s", role, CANDIDATE);
+        this.currTerm = term;
+        this.currVoteFor = leaderId;
+        this.changeToFollower(term, leaderId);
+    }
+
     public synchronized void changeToLeader(long term) {
         PreConditions.check(currTerm == term, DLedgerResponseCode.ILLEGAL_MEMBER_STATE, "%d != %d", currTerm, term);
         this.role = LEADER;

--- a/src/main/java/io/openmessaging/storage/dledger/protocol/VoteResponse.java
+++ b/src/main/java/io/openmessaging/storage/dledger/protocol/VoteResponse.java
@@ -67,6 +67,7 @@ public class VoteResponse extends RequestOrResponse {
         WAIT_TO_REVOTE,
         REVOTE_IMMEDIATELY,
         PASSED,
-        WAIT_TO_VOTE_NEXT;
+        WAIT_TO_VOTE_NEXT,
+        ILLEGAL
     }
 }


### PR DESCRIPTION
#85 

**Brief changelog**
- If biggerLedgerNum and smallerTermNum is more than half, parseResult is set to ILLEGAL  in candidate state.
-  When the node processes the heartbeat, if the requested term is smaller than the current node term, and lastParseResult is ILLEGAL, the node is reset to follower.