### PR TITLE
[ISSUE #90] suppport multiple preferred leader

### DIFF
--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerConfig.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerConfig.java
@@ -80,7 +80,7 @@ public class DLedgerConfig {
     private boolean enablePushToFollower = true;
 
     @Parameter(names = {"--preferred-leader-id"}, description = "Preferred LeaderId")
-    private String preferredLeaderId;
+    private String preferredLeaderIds;
     private long maxLeadershipTransferWaitIndex = 1000;
     private int minTakeLeadershipVoteIntervalMs =  30;
     private int maxTakeLeadershipVoteIntervalMs =  100;
@@ -341,12 +341,22 @@ public class DLedgerConfig {
         this.checkPointInterval = checkPointInterval;
     }
 
+    @Deprecated
     public String getPreferredLeaderId() {
-        return preferredLeaderId;
+        return preferredLeaderIds;
     }
 
+    @Deprecated
     public void setPreferredLeaderId(String preferredLeaderId) {
-        this.preferredLeaderId = preferredLeaderId;
+        this.preferredLeaderIds = preferredLeaderId;
+    }
+
+    public String getPreferredLeaderIds() {
+        return preferredLeaderIds;
+    }
+
+    public void setPreferredLeaderIds(String preferredLeaderIds) {
+        this.preferredLeaderIds = preferredLeaderIds;
     }
 
     public long getMaxLeadershipTransferWaitIndex() {

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerLeaderElector.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerLeaderElector.java
@@ -27,6 +27,7 @@ import io.openmessaging.storage.dledger.protocol.VoteResponse;
 import io.openmessaging.storage.dledger.utils.DLedgerUtils;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
@@ -372,8 +373,11 @@ public class DLedgerLeaderElector {
     }
 
     private boolean isTakingLeadership() {
-        return memberState.getSelfId().equals(dLedgerConfig.getPreferredLeaderId())
-            || memberState.getTermToTakeLeadership() == memberState.currTerm();
+        if (dLedgerConfig.getPreferredLeaderIds() != null && memberState.getTermToTakeLeadership() == memberState.currTerm()) {
+            List<String> preferredLeaderIds = Arrays.asList(dLedgerConfig.getPreferredLeaderIds().split(";"));
+            return preferredLeaderIds.contains(memberState.getSelfId());
+        }
+        return false;
     }
 
     private long getNextTimeToRequestVote() {

--- a/src/test/java/io/openmessaging/storage/dledger/AppendAndGetTest.java
+++ b/src/test/java/io/openmessaging/storage/dledger/AppendAndGetTest.java
@@ -140,7 +140,7 @@ public class AppendAndGetTest extends ServerTestHarness {
             request.setBody(("testThreeServerInFileWithAsyncRequests" + i).getBytes());
             futures.add(dLedgerServer1.handleAppend(request));
         }
-        Thread.sleep(500);
+        Thread.sleep(1000);
         Assert.assertEquals(9, dLedgerServer0.getdLedgerStore().getLedgerEndIndex());
         Assert.assertEquals(9, dLedgerServer1.getdLedgerStore().getLedgerEndIndex());
         Assert.assertEquals(9, dLedgerServer2.getdLedgerStore().getLedgerEndIndex());

--- a/src/test/java/io/openmessaging/storage/dledger/BatchPushTest.java
+++ b/src/test/java/io/openmessaging/storage/dledger/BatchPushTest.java
@@ -78,7 +78,7 @@ public class BatchPushTest extends ServerTestHarness{
             request.setBody(("testBatchPushWithAsyncRequests" + i).getBytes());
             futures.add(dLedgerServer1.handleAppend(request));
         }
-        Thread.sleep(500);
+        Thread.sleep(1000);
         Assert.assertEquals(9, dLedgerServer0.getdLedgerStore().getLedgerEndIndex());
         Assert.assertEquals(9, dLedgerServer1.getdLedgerStore().getLedgerEndIndex());
         Assert.assertEquals(9, dLedgerServer2.getdLedgerStore().getLedgerEndIndex());

--- a/src/test/java/io/openmessaging/storage/dledger/LeaderElectorTest.java
+++ b/src/test/java/io/openmessaging/storage/dledger/LeaderElectorTest.java
@@ -149,7 +149,7 @@ public class LeaderElectorTest extends ServerTestHarness {
         while (parseServers(servers, leaderNum, followerNum) == null && DLedgerUtils.elapsed(start) < 1000) {
             Thread.sleep(100);
         }
-        Thread.sleep(300);
+        Thread.sleep(1000);
         leaderNum.set(0);
         followerNum.set(0);
         DLedgerServer leaderServer = parseServers(servers, leaderNum, followerNum);
@@ -170,7 +170,7 @@ public class LeaderElectorTest extends ServerTestHarness {
         while (parseServers(leftServers, leaderNum, followerNum) == null && DLedgerUtils.elapsed(start) < 3 * leaderServer.getdLedgerConfig().getHeartBeatTimeIntervalMs()) {
             Thread.sleep(100);
         }
-        Thread.sleep(300);
+        Thread.sleep(1000);
         leaderNum.set(0);
         followerNum.set(0);
         Assert.assertNotNull(parseServers(leftServers, leaderNum, followerNum));


### PR DESCRIPTION
#90 

- Support setting multiple preferredLeaders, separated by ';', compatible with a single situation
- Multiple preferredLeaders, randomly select one of them for processing