### PR TITLE
[ISSUE #94] Batch push compatible with single push

### DIFF
--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerEntryPusher.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerEntryPusher.java
@@ -768,18 +768,16 @@ public class DLedgerEntryPusher {
             CompletableFuture<PushEntryResponse> future = new TimeoutFuture<>(1000);
             switch (request.getType()) {
                 case APPEND:
-                    if (dLedgerConfig.isEnableBatchPush()) {
+                    if (request.isBatch()) {
                         PreConditions.check(request.getBatchEntry() != null && request.getCount() > 0, DLedgerResponseCode.UNEXPECTED_ARGUMENT);
-                        long firstIndex = request.getFirstEntryIndex();
-                        writeRequestMap.put(firstIndex, new Pair<>(request, future));
                     } else {
                         PreConditions.check(request.getEntry() != null, DLedgerResponseCode.UNEXPECTED_ARGUMENT);
-                        long index = request.getEntry().getIndex();
-                        Pair<PushEntryRequest, CompletableFuture<PushEntryResponse>> old = writeRequestMap.putIfAbsent(index, new Pair<>(request, future));
-                        if (old != null) {
-                            logger.warn("[MONITOR]The index {} has already existed with {} and curr is {}", index, old.getKey().baseInfo(), request.baseInfo());
-                            future.complete(buildResponse(request, DLedgerResponseCode.REPEATED_PUSH.getCode()));
-                        }
+                    }
+                    long index = request.getFirstEntryIndex();
+                    Pair<PushEntryRequest, CompletableFuture<PushEntryResponse>> old = writeRequestMap.putIfAbsent(index, new Pair<>(request, future));
+                    if (old != null) {
+                        logger.warn("[MONITOR]The index {} has already existed with {} and curr is {}", index, old.getKey().baseInfo(), request.baseInfo());
+                        future.complete(buildResponse(request, DLedgerResponseCode.REPEATED_PUSH.getCode()));
                     }
                     break;
                 case COMMIT:
@@ -901,55 +899,17 @@ public class DLedgerEntryPusher {
         private void checkAppendFuture(long endIndex) {
             long minFastForwardIndex = Long.MAX_VALUE;
             for (Pair<PushEntryRequest, CompletableFuture<PushEntryResponse>> pair : writeRequestMap.values()) {
-                long index = pair.getKey().getEntry().getIndex();
-                //Fall behind
-                if (index <= endIndex) {
-                    try {
-                        DLedgerEntry local = dLedgerStore.get(index);
-                        PreConditions.check(pair.getKey().getEntry().equals(local), DLedgerResponseCode.INCONSISTENT_STATE);
-                        pair.getValue().complete(buildResponse(pair.getKey(), DLedgerResponseCode.SUCCESS.getCode()));
-                        logger.warn("[PushFallBehind]The leader pushed an entry index={} smaller than current ledgerEndIndex={}, maybe the last ack is missed", index, endIndex);
-                    } catch (Throwable t) {
-                        logger.error("[PushFallBehind]The leader pushed an entry index={} smaller than current ledgerEndIndex={}, maybe the last ack is missed", index, endIndex, t);
-                        pair.getValue().complete(buildResponse(pair.getKey(), DLedgerResponseCode.INCONSISTENT_STATE.getCode()));
-                    }
-                    writeRequestMap.remove(index);
-                    continue;
-                }
-                //Just OK
-                if (index == endIndex + 1) {
-                    //The next entry is coming, just return
-                    return;
-                }
-                //Fast forward
-                TimeoutFuture<PushEntryResponse> future = (TimeoutFuture<PushEntryResponse>) pair.getValue();
-                if (!future.isTimeOut()) {
-                    continue;
-                }
-                if (index < minFastForwardIndex) {
-                    minFastForwardIndex = index;
-                }
-            }
-            if (minFastForwardIndex == Long.MAX_VALUE) {
-                return;
-            }
-            Pair<PushEntryRequest, CompletableFuture<PushEntryResponse>> pair = writeRequestMap.get(minFastForwardIndex);
-            if (pair == null) {
-                return;
-            }
-            logger.warn("[PushFastForward] ledgerEndIndex={} entryIndex={}", endIndex, minFastForwardIndex);
-            pair.getValue().complete(buildResponse(pair.getKey(), DLedgerResponseCode.INCONSISTENT_STATE.getCode()));
-        }
-
-        private void checkBatchAppendFuture(long endIndex) {
-            long minFastForwardIndex = Long.MAX_VALUE;
-            for (Pair<PushEntryRequest, CompletableFuture<PushEntryResponse>> pair : writeRequestMap.values()) {
                 long firstEntryIndex = pair.getKey().getFirstEntryIndex();
                 long lastEntryIndex = pair.getKey().getLastEntryIndex();
                 //Fall behind
                 if (lastEntryIndex <= endIndex) {
                     try {
-                        for (DLedgerEntry dLedgerEntry : pair.getKey().getBatchEntry()) {
+                        if (pair.getKey().isBatch()) {
+                            for (DLedgerEntry dLedgerEntry : pair.getKey().getBatchEntry()) {
+                                PreConditions.check(dLedgerEntry.equals(dLedgerStore.get(dLedgerEntry.getIndex())), DLedgerResponseCode.INCONSISTENT_STATE);
+                            }
+                        } else {
+                            DLedgerEntry dLedgerEntry = pair.getKey().getEntry();
                             PreConditions.check(dLedgerEntry.equals(dLedgerStore.get(dLedgerEntry.getIndex())), DLedgerResponseCode.INCONSISTENT_STATE);
                         }
                         pair.getValue().complete(buildBatchAppendResponse(pair.getKey(), DLedgerResponseCode.SUCCESS.getCode()));
@@ -996,11 +956,8 @@ public class DLedgerEntryPusher {
             if (writeRequestMap.isEmpty()) {
                 return;
             }
-            if (dLedgerConfig.isEnableBatchPush()) {
-                checkBatchAppendFuture(endIndex);
-            } else {
-                checkAppendFuture(endIndex);
-            }
+
+            checkAppendFuture(endIndex);
         }
 
         @Override
@@ -1035,7 +992,7 @@ public class DLedgerEntryPusher {
                         return;
                     }
                     PushEntryRequest request = pair.getKey();
-                    if (dLedgerConfig.isEnableBatchPush()) {
+                    if (request.isBatch()) {
                         handleDoBatchAppend(nextIndex, request, pair.getValue());
                     } else {
                         handleDoAppend(nextIndex, request, pair.getValue());

--- a/src/main/java/io/openmessaging/storage/dledger/protocol/PushEntryRequest.java
+++ b/src/main/java/io/openmessaging/storage/dledger/protocol/PushEntryRequest.java
@@ -66,6 +66,8 @@ public class PushEntryRequest extends RequestOrResponse {
     public long getFirstEntryIndex() {
         if (!batchEntry.isEmpty()) {
             return batchEntry.get(0).getIndex();
+        } else if (entry != null) {
+            return entry.getIndex();
         } else {
             return -1;
         }
@@ -74,6 +76,8 @@ public class PushEntryRequest extends RequestOrResponse {
     public long getLastEntryIndex() {
         if (!batchEntry.isEmpty()) {
             return batchEntry.get(batchEntry.size() - 1).getIndex();
+        } else if (entry != null) {
+            return entry.getIndex();
         } else {
             return -1;
         }
@@ -94,6 +98,10 @@ public class PushEntryRequest extends RequestOrResponse {
     public void clear() {
         batchEntry.clear();
         totalSize = 0;
+    }
+
+    public boolean isBatch() {
+        return !batchEntry.isEmpty();
     }
 
     public enum Type {


### PR DESCRIPTION
#94 

**Optimization logic**
According to the configuration enableBatchPush, choose whether to synchronize data through batch. When a push request is received, it is judged whether it is a batch push according to the number of messages sent.
