### PR TITLE
[ISSUE #97] Performance optimization

### DIFF
--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerEntryPusher.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerEntryPusher.java
@@ -739,7 +739,7 @@ public class DLedgerEntryPusher {
                 } else {
                     doCompare();
                 }
-                waitForRunning(1);
+                Thread.yield();
             } catch (Throwable t) {
                 DLedgerEntryPusher.logger.error("[Push-{}]Error in {} writeIndex={} compareIndex={}", peerId, getName(), writeIndex, compareIndex, t);
                 DLedgerUtils.sleep(500);
@@ -796,6 +796,7 @@ public class DLedgerEntryPusher {
                     future.complete(buildResponse(request, DLedgerResponseCode.UNEXPECTED_ARGUMENT.getCode()));
                     break;
             }
+            wakeup();
             return future;
         }
 


### PR DESCRIPTION
Too much text, so I write in Chinese。
我发现rocketmq 在 dledger 模式下 性能不是很好，可以看：https://github.com/apache/rocketmq/issues/3315
rocketmq， 4.9.1 ，16c， 32g   ，1wtps，p99 很难到达 2ms 以下，最好的情况也需要 3ms。
我重新编译了代码发现瓶颈在 raft 同步数据上，写完pageccache 后等待同步完成平均需要 1.7ms。
我在dledger 代码中发现了几个问题，我尝试修改了dledger 的代码，之后进行了测试，3wtps 下 p99 到达了 1-2ms。
平均耗时 0.8-1ms。大约提升了1ms。

修改项：
1.
src/main/java/io/openmessaging/storage/dledger/DLedgerEntryPusher.java  745 
将waitForRunning(1);  改为 Thread.yield();
设计思想应该是 如果一直有消息进入推动 dLedgerStore.getLedgerEndIndex() 的数值变大，就不会break 循环去执行waitForRunning(1); 
但经过我的测试 在 1w tps  下 waitForRunning(1); 执行的非常频繁每次都会休眠 1ms ，因为有新消息时并不会 wakeup(); 唤醒线程。我猜可能是 getLedgerEndIndex() 访问的  ledgerEndIndex 属性没有被 volatile 修饰？

481行
                if (writeIndex > dLedgerStore.getLedgerEndIndex()) { 
                    doCommit();
                    doCheckAppendResponse();
                    break; //break 循环去执行 waitForRunning(1); 
                }

2.
src/main/java/io/openmessaging/storage/dledger/DLedgerEntryPusher.java  799
增加 wakeup(); 在有新消息时唤醒 线程

3.
src/main/java/io/openmessaging/storage/dledger/store/file/DLedgerMmapFileStore.java
提出一个新方法用于获取 消息的 pos 和 size
原来的方法从index 文件读完就已经能得知pos 和 size ，还有钱commitlog 里面读消息体加上解码

但是getCommittedIndex 只是需要 pos 和size。
这样修改完成后相比之前少了一个 check 
 PreConditions.check(pos == dLedgerEntry.getPos(), DLedgerResponseCode.DISK_ERROR, "%d != %d", pos, dLedgerEntry.getPos());
是否会有问题呢








