### PR TITLE
The variable DLedgerMmapFileStore#isDiskFull should be decorated with the volatile.

### DIFF
--- a/src/main/java/io/openmessaging/storage/dledger/store/file/DLedgerMmapFileStore.java
+++ b/src/main/java/io/openmessaging/storage/dledger/store/file/DLedgerMmapFileStore.java
@@ -60,7 +60,7 @@ public class DLedgerMmapFileStore extends DLedgerStore {
     private ThreadLocal<ByteBuffer> localIndexBuffer;
     private FlushDataService flushDataService;
     private CleanSpaceService cleanSpaceService;
-    private boolean isDiskFull = false;
+    private volatile boolean isDiskFull = false;
 
     private long lastCheckPointTimeMs = System.currentTimeMillis();
 

--- a/src/main/java/io/openmessaging/storage/dledger/store/file/DLedgerMmapFileStore.java
+++ b/src/main/java/io/openmessaging/storage/dledger/store/file/DLedgerMmapFileStore.java
@@ -632,8 +632,9 @@ public class DLedgerMmapFileStore extends DLedgerStore {
                 long start = System.currentTimeMillis();
                 DLedgerMmapFileStore.this.dataFileList.flush(0);
                 DLedgerMmapFileStore.this.indexFileList.flush(0);
-                if (DLedgerUtils.elapsed(start) > 500) {
-                    logger.info("Flush data cost={} ms", DLedgerUtils.elapsed(start));
+                long elapsed;
+                if ((elapsed = DLedgerUtils.elapsed(start)) > 500) {
+                    logger.info("Flush data cost={} ms", elapsed);
                 }
 
                 if (DLedgerUtils.elapsed(lastCheckPointTimeMs) > dLedgerConfig.getCheckPointInterval()) {


### PR DESCRIPTION
For issue #103 

The variable `DLedgerMmapFileStore#isDiskFull` should be decorated with the **volatile**,

because it will be written by the thread `CleanSpaceService`, and it will be read by other threads when append `DLedgerEntry`.

