### PR TITLE
[ISSUE #111] It is better for the peer with the smallest lag(fall behind index) to become the transferee.

### DIFF
--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerServer.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerServer.java
@@ -356,11 +356,18 @@ public class DLedgerServer implements DLedgerProtocolHander {
         if (preferredLeaderIds.size() == 0) {
             return;
         }
-
+        long minFallBehind = Long.MAX_VALUE;
         String preferredLeaderId = preferredLeaderIds.get(0);
-        long fallBehind = dLedgerStore.getLedgerEndIndex() - dLedgerEntryPusher.getPeerWaterMark(memberState.currTerm(), preferredLeaderId);
-        logger.info("transferee fall behind index : {}", fallBehind);
-        if (fallBehind < dLedgerConfig.getMaxLeadershipTransferWaitIndex()) {
+        for (String peerId : preferredLeaderIds) {
+            long fallBehind = dLedgerStore.getLedgerEndIndex() - dLedgerEntryPusher.getPeerWaterMark(memberState.currTerm(), peerId);
+            if (fallBehind < minFallBehind) {
+                minFallBehind = fallBehind;
+                preferredLeaderId = peerId;
+            }
+        }
+        logger.info("preferredLeaderId = {}, which has the smallest fall behind index = {} and is decided to be transferee.", preferredLeaderId, minFallBehind);
+        
+        if (minFallBehind < dLedgerConfig.getMaxLeadershipTransferWaitIndex()) {
             LeadershipTransferRequest request = new LeadershipTransferRequest();
             request.setTerm(memberState.currTerm());
             request.setTransfereeId(preferredLeaderId);


### PR DESCRIPTION
For issue #111 

- In method `DLedgerServer#checkPreferredLeader()`, The first peer in the list `preferredLeaderIds` that meets the condition is determined to be the leader `transferee`
- I think, the peer with the smallest lag(fall behind index) be the `transferee`, which may be better.