### PR TITLE
[ISSUE #126] The class DLedgerProtocolHander name should be DLedgerProtocolHandler

### DIFF
--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerRpcService.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerRpcService.java
@@ -17,9 +17,9 @@
 package io.openmessaging.storage.dledger;
 
 import io.openmessaging.storage.dledger.protocol.DLedgerProtocol;
-import io.openmessaging.storage.dledger.protocol.DLedgerProtocolHander;
+import io.openmessaging.storage.dledger.protocol.DLedgerProtocolHandler;
 
-public abstract class DLedgerRpcService implements DLedgerProtocol, DLedgerProtocolHander {
+public abstract class DLedgerRpcService implements DLedgerProtocol, DLedgerProtocolHandler {
 
     public abstract void startup();
 

--- a/src/main/java/io/openmessaging/storage/dledger/DLedgerServer.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedgerServer.java
@@ -21,7 +21,7 @@ import io.openmessaging.storage.dledger.exception.DLedgerException;
 import io.openmessaging.storage.dledger.protocol.AppendEntryRequest;
 import io.openmessaging.storage.dledger.protocol.AppendEntryResponse;
 import io.openmessaging.storage.dledger.protocol.BatchAppendEntryRequest;
-import io.openmessaging.storage.dledger.protocol.DLedgerProtocolHander;
+import io.openmessaging.storage.dledger.protocol.DLedgerProtocolHandler;
 import io.openmessaging.storage.dledger.protocol.DLedgerResponseCode;
 import io.openmessaging.storage.dledger.protocol.GetEntriesRequest;
 import io.openmessaging.storage.dledger.protocol.GetEntriesResponse;
@@ -58,7 +58,7 @@ import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DLedgerServer implements DLedgerProtocolHander {
+public class DLedgerServer implements DLedgerProtocolHandler {
 
     private static Logger logger = LoggerFactory.getLogger(DLedgerServer.class);
 

--- a/src/main/java/io/openmessaging/storage/dledger/protocol/DLedgerProtocolHandler.java
+++ b/src/main/java/io/openmessaging/storage/dledger/protocol/DLedgerProtocolHandler.java
@@ -21,7 +21,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * Both the RaftLogServer(inbound) and RaftRpcService (outbound) should implement this protocol
  */
-public interface DLedgerProtocolHander extends DLedgerClientProtocolHandler {
+public interface DLedgerProtocolHandler extends DLedgerClientProtocolHandler {
 
     CompletableFuture<VoteResponse> handleVote(VoteRequest request) throws Exception;
 


### PR DESCRIPTION
renamed DLedgerProtocolHander to DLedgerProtocolHandler. #126 