### PR TITLE
Update org.slf4j-log4j12@1.7.6 to org.slf4j-log4j12@1.7.36

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.6</version>
+            <version>1.7.36</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Update slf4j-log4j12 dependency to the newest stable released version to fix vulnerabilities within the original version.