### PR TITLE
Make StateMachineCaller thread will not exit when throw exception

### DIFF
--- a/src/main/java/io/openmessaging/storage/dledger/statemachine/StateMachineCaller.java
+++ b/src/main/java/io/openmessaging/storage/dledger/statemachine/StateMachineCaller.java
@@ -136,6 +136,8 @@ public class StateMachineCaller extends ServiceThread {
                 }
             } catch (final InterruptedException e) {
                 logger.error("Error happen in {} when pull task from task queue", getServiceName(), e);
+            } catch (Throwable e) {
+                logger.error("Apply task exception", e);
             }
         }
     }


### PR DESCRIPTION
Make StateMachineCaller thread will not exit when throw exception