### PR TITLE
[ISSUE #177] update rocketmq-remoting version 4.3.2 to 4.9.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.apache.rocketmq</groupId>
             <artifactId>rocketmq-remoting</artifactId>
-            <version>4.3.2</version>
+            <version>4.9.4</version>
         </dependency>
         <dependency>
             <groupId>com.beust</groupId>


### PR DESCRIPTION
[Fix 177 issue](https://github.com/openmessaging/dledger/issues/177)

- upgrade rocketmq-remoting version,NettyRemotingClient.createChannel method has a bug in high concurrency