### PR TITLE
[ISSUE #183]  fix MmapFileList LoggerFactory.getLogger method parameter incorrect

### DIFF
--- a/src/main/java/io/openmessaging/storage/dledger/store/file/MmapFileList.java
+++ b/src/main/java/io/openmessaging/storage/dledger/store/file/MmapFileList.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 public class MmapFileList {
     public static final int MIN_BLANK_LEN = 8;
     public static final int BLANK_MAGIC_CODE = -1;
-    private static Logger logger = LoggerFactory.getLogger(MmapFile.class);
+    private static Logger logger = LoggerFactory.getLogger(MmapFileList.class);
     private static final int DELETE_FILES_BATCH_MAX = 10;
     private final String storePath;
 

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -19,12 +19,12 @@
 <Configuration>
     <Appenders>
         <Console name="stdout" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %c{1}:%L - %m%n"/>
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} [%t] %-5p %c{1}:%L - %m%n"/>
         </Console>
         <RollingFile name="dledger" fileName="${sys:user.home}/logs/dledger/dledger.log"
                      filePattern="${sys:user.home}/logs/dledger/dledger.log.gz">
             <PatternLayout>
-                <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %c{1}:%L - %m%n</Pattern>
+                <Pattern>%d{yyyy-MM-dd HH:mm:ss,SSS} [%t] %-5p %c{1}:%L - %m%n</Pattern>
             </PatternLayout>
             <Policies>
                 <SizeBasedTriggeringPolicy size="500 MB" />


### PR DESCRIPTION
Fix #183 

- fix MmapFileList LoggerFactory.getLogger method parameter incorrect
- add thread information in the log print out