### PR TITLE
[ISSUE #192]Optimize BossCommand code and add ServerCommand

### DIFF
--- a/src/main/java/io/openmessaging/storage/dledger/DLedger.java
+++ b/src/main/java/io/openmessaging/storage/dledger/DLedger.java
@@ -24,10 +24,21 @@ import org.slf4j.LoggerFactory;
 public class DLedger {
 
     private static Logger logger = LoggerFactory.getLogger(DLedger.class);
-
+    
+    @Deprecated
     public static void main(String args[]) {
         DLedgerConfig dLedgerConfig = new DLedgerConfig();
         JCommander.newBuilder().addObject(dLedgerConfig).build().parse(args);
+        bootstrapDLedger(dLedgerConfig);
+    }
+
+    public static void bootstrapDLedger(DLedgerConfig dLedgerConfig) {
+
+        if (null == dLedgerConfig) {
+            logger.error("Bootstrap DLedger server error", new IllegalArgumentException("DLedgerConfig is null"));
+            System.exit(-1);
+        }
+
         DLedgerServer dLedgerServer = new DLedgerServer(dLedgerConfig);
         dLedgerServer.startup();
         logger.info("[{}] group {} start ok with config {}", dLedgerConfig.getSelfId(), dLedgerConfig.getGroup(), JSON.toJSONString(dLedgerConfig));

--- a/src/main/java/io/openmessaging/storage/dledger/cmdline/BossCommand.java
+++ b/src/main/java/io/openmessaging/storage/dledger/cmdline/BossCommand.java
@@ -17,8 +17,6 @@
 package io.openmessaging.storage.dledger.cmdline;
 
 import com.beust.jcommander.JCommander;
-import io.openmessaging.storage.dledger.DLedger;
-import io.openmessaging.storage.dledger.DLedgerConfig;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,13 +24,13 @@ public class BossCommand {
 
     public static void main(String args[]) {
         Map<String, BaseCommand> commands = new HashMap<>();
+        commands.put("server", new ServerCommand());
         commands.put("append", new AppendCommand());
         commands.put("get", new GetCommand());
         commands.put("readFile", new ReadFileCommand());
         commands.put("leadershipTransfer", new LeadershipTransferCommand());
 
         JCommander.Builder builder = JCommander.newBuilder();
-        builder.addCommand("server", new DLedgerConfig());
         for (String cmd : commands.keySet()) {
             builder.addCommand(cmd, commands.get(cmd));
         }
@@ -41,13 +39,9 @@ public class BossCommand {
 
         if (jc.getParsedCommand() == null) {
             jc.usage();
-        } else if (jc.getParsedCommand().equals("server")) {
-            String[] subArgs = new String[args.length - 1];
-            System.arraycopy(args, 1, subArgs, 0, subArgs.length);
-            DLedger.main(subArgs);
         } else {
             BaseCommand command = commands.get(jc.getParsedCommand());
-            if (command != null) {
+            if (null != command) {
                 command.doCommand();
             } else {
                 jc.usage();

--- a/src/main/java/io/openmessaging/storage/dledger/cmdline/GetCommand.java
+++ b/src/main/java/io/openmessaging/storage/dledger/cmdline/GetCommand.java
@@ -18,12 +18,14 @@ package io.openmessaging.storage.dledger.cmdline;
 
 import com.alibaba.fastjson.JSON;
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
 import io.openmessaging.storage.dledger.client.DLedgerClient;
 import io.openmessaging.storage.dledger.entry.DLedgerEntry;
 import io.openmessaging.storage.dledger.protocol.GetEntriesResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Parameters(commandDescription = "Get data from DLedger server")
 public class GetCommand extends BaseCommand {
 
     private static Logger logger = LoggerFactory.getLogger(GetCommand.class);

--- a/src/main/java/io/openmessaging/storage/dledger/cmdline/LeadershipTransferCommand.java
+++ b/src/main/java/io/openmessaging/storage/dledger/cmdline/LeadershipTransferCommand.java
@@ -18,12 +18,14 @@ package io.openmessaging.storage.dledger.cmdline;
 
 import com.alibaba.fastjson.JSON;
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
 import io.openmessaging.storage.dledger.client.DLedgerClient;
 import io.openmessaging.storage.dledger.protocol.DLedgerResponseCode;
 import io.openmessaging.storage.dledger.protocol.LeadershipTransferResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Parameters(commandDescription = "Leadership transfer")
 public class LeadershipTransferCommand extends BaseCommand {
 
     private static Logger logger = LoggerFactory.getLogger(LeadershipTransferCommand.class);

--- a/src/main/java/io/openmessaging/storage/dledger/cmdline/ReadFileCommand.java
+++ b/src/main/java/io/openmessaging/storage/dledger/cmdline/ReadFileCommand.java
@@ -18,6 +18,7 @@ package io.openmessaging.storage.dledger.cmdline;
 
 import com.alibaba.fastjson.JSON;
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
 import io.openmessaging.storage.dledger.entry.DLedgerEntry;
 import io.openmessaging.storage.dledger.entry.DLedgerEntryCoder;
 import io.openmessaging.storage.dledger.store.file.DLedgerMmapFileStore;
@@ -28,6 +29,7 @@ import java.nio.ByteBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Parameters(commandDescription = "Read data from DLedger server data file")
 public class ReadFileCommand extends BaseCommand {
 
     private static Logger logger = LoggerFactory.getLogger(ReadFileCommand.class);

--- a/src/main/java/io/openmessaging/storage/dledger/cmdline/ServerCommand.java
+++ b/src/main/java/io/openmessaging/storage/dledger/cmdline/ServerCommand.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017-2022 The DLedger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.openmessaging.storage.dledger.cmdline;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import io.openmessaging.storage.dledger.DLedger;
+import io.openmessaging.storage.dledger.DLedgerConfig;
+import java.io.File;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Parameters(commandDescription = "Bootstrap DLedger Server")
+public class ServerCommand extends BaseCommand {
+
+    private static Logger logger = LoggerFactory.getLogger(ServerCommand.class);
+
+    @Parameter(names = {"--group", "-g"}, description = "Group of this server")
+    private String group = "default";
+
+    @Parameter(names = {"--id", "-i"}, description = "Self id of this server")
+    private String selfId = "n0";
+
+    @Parameter(names = {"--peers", "-p"}, description = "Peer info of this server")
+    private String peers = "n0-localhost:20911";
+
+    @Parameter(names = {"--store-base-dir", "-s"}, description = "The base store dir of this server")
+    private String storeBaseDir = File.separator + "tmp" + File.separator + "dledgerstore";
+
+    @Parameter(names = {"--read-only-data-store-dirs"}, description = "The dirs of this server to be read only")
+    private String readOnlyDataStoreDirs = null;
+
+    @Parameter(names = {"--peer-push-throttle-point"}, description = "When the follower is behind the leader more than this value, it will trigger the throttle")
+    private int peerPushThrottlePoint = 300 * 1024 * 1024;
+
+    @Parameter(names = {"--peer-push-quotas"}, description = "The quotas of the pusher")
+    private int peerPushQuota = 20 * 1024 * 1024;
+
+    @Parameter(names = {"--preferred-leader-id"}, description = "Preferred LeaderId")
+    private String preferredLeaderIds = null;
+
+    @Override
+    public void doCommand() {
+        DLedgerConfig dLedgerConfig = buildDLedgerConfig();
+        DLedger.bootstrapDLedger(dLedgerConfig);
+        logger.info("Bootstrap DLedger Server success", selfId);
+    }
+
+    private DLedgerConfig buildDLedgerConfig() {
+        DLedgerConfig dLedgerConfig = new DLedgerConfig();
+        dLedgerConfig.setGroup(this.group);
+        dLedgerConfig.setSelfId(this.selfId);
+        dLedgerConfig.setPeers(this.peers);
+        dLedgerConfig.setStoreBaseDir(this.storeBaseDir);
+        dLedgerConfig.setReadOnlyDataStoreDirs(this.readOnlyDataStoreDirs);
+        dLedgerConfig.setPeerPushThrottlePoint(this.peerPushThrottlePoint);
+        dLedgerConfig.setPeerPushQuota(this.peerPushQuota);
+        dLedgerConfig.setPreferredLeaderIds(this.preferredLeaderIds);
+        return dLedgerConfig;
+    }
+}


### PR DESCRIPTION
Fix #192 

- Optimize BossCommand code and add ServerCommand
- GetCommand，LeadershipTransferCommand，ReadFileCommand add Parameters annotation and add command description for each.（Tips: AppendCommand command description was added in this PR #188 ）
```shell
Usage: <main class> [command] [command options]
  Commands:
    server      Bootstrap DLedger Server
      Usage: server [options]
        Options:
          --group, -g
            Group of this server
            Default: default
          --id, -i
            Self id of this server
            Default: n0
          --peer-push-quotas
            The quotas of the pusher
            Default: 20971520
          --peer-push-throttle-point
            When the follower is behind the leader more than this value, it 
            will trigger the throttle
            Default: 314572800
          --peers, -p
            Peer info of this server
            Default: n0-localhost:20911
          --preferred-leader-id
            Preferred LeaderId
          --read-only-data-store-dirs
            The dirs of this server to be read only
          --store-base-dir, -s
            The base store dir of this server
            Default: \tmp\dledgerstore

    readFile      Read data from DLedger server data file
      Usage: readFile [options]
        Options:
          --body, -b
            if read the body
            Default: false
          --dir, -d
            the data dir
          --index, -i
            the index
            Default: -1
          --pos, -p
            the start pos
            Default: 0
          --size, -s
            the file size
            Default: -1

    get      Get data from DLedger server
      Usage: get [options]
        Options:
          --group, -g
            Group of this server
            Default: default
          --index, -i
            get entry from index
            Default: 0
          --peers, -p
            Peer info of this server
            Default: n0-localhost:20911

    leadershipTransfer      Leadership transfer
      Usage: leadershipTransfer [options]
        Options:
          --group, -g
            Group of this server
            Default: default
          --leader, -l
            set the current leader manually
          --peers, -p
            Peer info of this server
            Default: n0-localhost:20911
          --term
            current term
            Default: 0
          --transfereeId, -t
            Node try to be the new leader
            Default: n0

    append      null
      Usage: append [options]
        Options:
          --count, -c
            append several times
            Default: 1
          --data, -d
            the data to append
            Default: Hello
          --group, -g
            Group of this server
            Default: default
          --peers, -p
            Peer info of this server
            Default: n0-localhost:20911

```