### PR TITLE
Add a lightweight log implementation slf4j-simple

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,11 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.7.36</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.36</version>
+        </dependency>
         <!-- Test only dependencies follow -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/src/main/java/io/openmessaging/storage/dledger/store/file/DLedgerMmapFileStore.java
+++ b/src/main/java/io/openmessaging/storage/dledger/store/file/DLedgerMmapFileStore.java
@@ -77,7 +77,7 @@ public class DLedgerMmapFileStore extends DLedgerStore {
         this.memberState = memberState;
         if (dLedgerConfig.getDataStorePath().contains(DLedgerConfig.MULTI_PATH_SPLITTER)) {
             this.dataFileList = new MultiPathMmapFileList(dLedgerConfig, dLedgerConfig.getMappedFileSizeForEntryData(),
-                    this::getFullStorePaths);
+                this::getFullStorePaths);
         } else {
             this.dataFileList = new MmapFileList(dLedgerConfig.getDataStorePath(), dLedgerConfig.getMappedFileSizeForEntryData());
         }
@@ -218,7 +218,7 @@ public class DLedgerMmapFileStore extends DLedgerStore {
                 }
 
                 int size = byteBuffer.getInt();
-                if(size == 0){
+                if (size == 0) {
                     logger.info("Recover data file to the end of {} ", mappedFile.getFileName());
                     break;
                 }
@@ -567,6 +567,7 @@ public class DLedgerMmapFileStore extends DLedgerStore {
             SelectMmapBufferResult.release(indexSbr);
         }
     }
+
     public void indexCheck(Long index) {
         PreConditions.check(index >= 0, DLedgerResponseCode.INDEX_OUT_OF_RANGE, "%d should gt 0", index);
         PreConditions.check(index >= ledgerBeginIndex, DLedgerResponseCode.INDEX_LESS_THAN_LOCAL_BEGIN, "%d should be gt %d, ledgerBeginIndex may be revised", index, ledgerBeginIndex);
@@ -690,10 +691,10 @@ public class DLedgerMmapFileStore extends DLedgerStore {
                 storeBaseRatio = DLedgerUtils.getDiskPartitionSpaceUsedPercent(dLedgerConfig.getStoreBaseDir());
                 dataRatio = calcDataStorePathPhysicRatio();
                 long hourOfMs = 3600L * 1000L;
-                long fileReservedTimeMs = dLedgerConfig.getFileReservedHours() *  hourOfMs;
+                long fileReservedTimeMs = dLedgerConfig.getFileReservedHours() * hourOfMs;
                 if (fileReservedTimeMs < hourOfMs) {
                     logger.warn("The fileReservedTimeMs={} is smaller than hourOfMs={}", fileReservedTimeMs, hourOfMs);
-                    fileReservedTimeMs =  hourOfMs;
+                    fileReservedTimeMs = hourOfMs;
                 }
                 //If the disk is full, should prevent more data to get in
                 DLedgerMmapFileStore.this.isDiskFull = isNeedForbiddenWrite();


### PR DESCRIPTION
Add a lightweight log implementation slf4j-simple, so that the dledger can output logs when running independently