### PR TITLE
fix: follower should try clean pending closure to avoid memory leak

### DIFF
--- a/dledger/src/main/java/io/openmessaging/storage/dledger/DLedgerEntryPusher.java
+++ b/dledger/src/main/java/io/openmessaging/storage/dledger/DLedgerEntryPusher.java
@@ -226,6 +226,7 @@ public class DLedgerEntryPusher {
                     break;
                 } else if (closure.isTimeOut()) {
                     closure.done(Status.error(DLedgerResponseCode.WAIT_QUORUM_ACK_TIMEOUT));
+                    closureMap.remove(i);
                 } else {
                     break;
                 }
@@ -267,10 +268,7 @@ public class DLedgerEntryPusher {
                         memberState.getSelfId(), memberState.getRole(), memberState.currTerm(), dLedgerStore.getLedgerBeforeBeginIndex(), dLedgerStore.getLedgerEndIndex(), memberState.getCommittedIndex(), JSON.toJSONString(peerWaterMarksByTerm), memberState.getAppliedIndex());
                     lastPrintWatermarkTimeMs = System.currentTimeMillis();
                 }
-                if (!memberState.isLeader()) {
-                    waitForRunning(1);
-                    return;
-                }
+                
                 long currTerm = memberState.currTerm();
                 checkTermForPendingMap(currTerm, "QuorumAckChecker");
                 checkTermForWaterMark(currTerm, "QuorumAckChecker");
@@ -307,6 +305,10 @@ public class DLedgerEntryPusher {
                 // clear the timeout pending closure which index > appliedIndex
                 checkResponseFuturesTimeout(DLedgerEntryPusher.this.memberState.getAppliedIndex() + 1);
 
+                if (!memberState.isLeader()) {
+                    waitForRunning(1);
+                    return;
+                }
                 // update peer watermarks of self
                 updatePeerWaterMark(currTerm, memberState.getSelfId(), dLedgerStore.getLedgerEndIndex());
 

--- a/dledger/src/main/java/io/openmessaging/storage/dledger/DLedgerEntryPusher.java
+++ b/dledger/src/main/java/io/openmessaging/storage/dledger/DLedgerEntryPusher.java
@@ -223,7 +223,7 @@ public class DLedgerEntryPusher {
             maxIndex = this.memberState.getLedgerEndIndex() + 1;
         }
         ConcurrentMap<Long, Closure> closureMap = this.pendingClosure.get(term);
-        if (closureMap != null) {
+        if (closureMap != null && closureMap.size() > 0) {
             for (long i = beginIndex; i < maxIndex; i++) {
                 Closure closure = closureMap.get(i);
                 if (closure == null) {

--- a/dledger/src/main/java/io/openmessaging/storage/dledger/statemachine/StateMachineCaller.java
+++ b/dledger/src/main/java/io/openmessaging/storage/dledger/statemachine/StateMachineCaller.java
@@ -203,7 +203,7 @@ public class StateMachineCaller extends ShutdownAbleThread {
         // Check response timeout.
         if (iter.getCompleteAckNums() == 0) {
             if (this.entryPusher != null) {
-                this.entryPusher.checkResponseFuturesTimeout(this.memberState.getAppliedIndex() + 1);
+                this.entryPusher.checkResponseFuturesTimeout();
             }
         }
     }

--- a/dledger/src/main/java/io/openmessaging/storage/dledger/statemachine/StateMachineCaller.java
+++ b/dledger/src/main/java/io/openmessaging/storage/dledger/statemachine/StateMachineCaller.java
@@ -203,7 +203,7 @@ public class StateMachineCaller extends ShutdownAbleThread {
         // Check response timeout.
         if (iter.getCompleteAckNums() == 0) {
             if (this.entryPusher != null) {
-                this.entryPusher.checkResponseFuturesTimeout();
+                this.entryPusher.checkResponseFuturesTimeout(this.memberState.getAppliedIndex() + 1);
             }
         }
     }

--- a/dledger/src/test/java/io/openmessaging/storage/dledger/AppendAndPushTest.java
+++ b/dledger/src/test/java/io/openmessaging/storage/dledger/AppendAndPushTest.java
@@ -33,6 +33,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.awaitility.core.AssertionCondition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -88,7 +90,7 @@ public class AppendAndPushTest extends ServerTestHarness {
             futures.add(future);
         }
         Assertions.assertEquals(9, dLedgerServer0.getDLedgerStore().getLedgerEndIndex());
-        Thread.sleep(dLedgerServer0.getDLedgerConfig().getMaxWaitAckTimeMs() + 100);
+        Thread.sleep(dLedgerServer0.getDLedgerConfig().getMaxWaitAckTimeMs() + 1000);
         for (int i = 0; i < futures.size(); i++) {
             CompletableFuture<AppendEntryResponse> future = futures.get(i);
             Assertions.assertTrue(future.isDone());
@@ -96,7 +98,7 @@ public class AppendAndPushTest extends ServerTestHarness {
         }
 
         boolean hasWait = false;
-        for (int i = 0; i < dLedgerServer0.getDLedgerConfig().getMaxPendingRequestsNum(); i++) {
+        for (int i = 0; i < dLedgerServer0.getDLedgerConfig().getMaxPendingRequestsNum()+2; i++) {
             AppendEntryRequest appendEntryRequest = new AppendEntryRequest();
             appendEntryRequest.setGroup(group);
             appendEntryRequest.setRemoteId(dLedgerServer0.getMemberState().getSelfId());

--- a/dledger/src/test/java/io/openmessaging/storage/dledger/BatchPushTest.java
+++ b/dledger/src/test/java/io/openmessaging/storage/dledger/BatchPushTest.java
@@ -126,7 +126,7 @@ public class BatchPushTest extends ServerTestHarness {
             futures.add(future);
         }
         Assertions.assertEquals(9, dLedgerServer0.getDLedgerStore().getLedgerEndIndex());
-        Thread.sleep(dLedgerServer0.getDLedgerConfig().getMaxWaitAckTimeMs() + 100);
+        Thread.sleep(dLedgerServer0.getDLedgerConfig().getMaxWaitAckTimeMs() + 1000);
         for (int i = 0; i < futures.size(); i++) {
             CompletableFuture<AppendEntryResponse> future = futures.get(i);
             Assertions.assertTrue(future.isDone());
@@ -134,7 +134,7 @@ public class BatchPushTest extends ServerTestHarness {
         }
 
         boolean hasWait = false;
-        for (int i = 0; i < dLedgerServer0.getDLedgerConfig().getMaxPendingRequestsNum(); i++) {
+        for (int i = 0; i < dLedgerServer0.getDLedgerConfig().getMaxPendingRequestsNum() + 2; i++) {
             AppendEntryRequest appendEntryRequest = new AppendEntryRequest();
             appendEntryRequest.setGroup(group);
             appendEntryRequest.setRemoteId(dLedgerServer0.getMemberState().getSelfId());

--- a/dledger/src/test/java/io/openmessaging/storage/dledger/ServerTestHarness.java
+++ b/dledger/src/test/java/io/openmessaging/storage/dledger/ServerTestHarness.java
@@ -67,6 +67,7 @@ public class ServerTestHarness extends ServerTestBase {
         config.setEnableLeaderElector(false);
         config.setEnableDiskForceClean(false);
         config.setDiskSpaceRatioToForceClean(0.90f);
+        config.setMaxPendingRequestsNum(1000);
         DLedgerServer dLedgerServer = new DLedgerServer(config);
         MemberState memberState = dLedgerServer.getMemberState();
         memberState.setCurrTermForTest(0);


### PR DESCRIPTION
Change-Id: I24b4cc67d66d7fba3ae4c46480da1af1c769479d

Fix some possible memory leak:
1. timeout response check should remove map index
2. follower should check and clean old pending closure since it may changed from leader which will has old data
